### PR TITLE
Fix/shadow gradle9 compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.5.15] - 2026-07-01
+- **Gradle 9 Compatibility Fix**: Migrated the Android build from the unmaintained `com.github.johnrengelman.shadow` plugin 8.1.1 to the maintained fork `com.gradleup.shadow` 8.3.11. The old plugin fails on Gradle 9 with `MissingPropertyException: No such property: mode` (Gradle 9 removed `FileCopyDetails.mode`), halting the whole application build. The replacement uses the same `ShadowJar` task class and produces an identical shaded BouncyCastle jar; verified on Gradle 8.8, 8.10.2, and 9.0.0. Minimum supported Gradle remains 8.3 (React Native 0.76+ ships 8.10+), so no consumer action is required beyond updating the package.
+
 ## [3.5.14] - 2026-05-06
 - **SDK Call Guards**: Added `isApproovEnabled` guards to all public methods that call the native Approov SDK without first checking initialization state. On Android: `setDevKey`, `setInstallAttrsInToken`, `getMessageSignature`, `getAccountMessageSignature`, and `getInstallMessageSignature`. On iOS: `setDevKey`, `setInstallAttrsInToken`, `getMessageSignature`, and `getDeviceID`. These methods now safely reject the promise (or throw `ApproovException` for static helpers) instead of crashing when the service layer is uninitialized or running in bypass mode.
 - **Android Request Mutation Logging**: Added an INFO-level `request mutation` log line to the Android OkHttp interceptor that confirms the `Approov-Token` and trace ID headers were actually injected onto the outgoing request. The log uses the same `missing`/`empty`/`present(len=N)` format as the iOS `task mutation` log, closing an observability gap where token fetch was logged but header injection was silent.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ buildscript {
 }
 
 plugins {
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    id 'com.gradleup.shadow' version '8.3.11'
 }
 
 def DEFAULT_COMPILE_SDK_VERSION = 34

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@approov/approov-service-react-native",
-  "version": "3.5.14",
+  "version": "3.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@approov/approov-service-react-native",
-      "version": "3.5.14",
+      "version": "3.5.15",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.28.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@approov/approov-service-react-native",
-  "version": "3.5.14",
+  "version": "3.5.15",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
fix(android): migrate shadow plugin for Gradle 9
The com.github.johnrengelman.shadow plugin 8.1.1 is unmaintained and
fails on Gradle 9 with MissingPropertyException (Gradle removed
FileCopyDetails.mode), halting customer React Native builds.

Switch to the maintained fork com.gradleup.shadow 8.3.11: same
ShadowJar task class, minimum Gradle 8.3 (RN >= 0.76 ships 8.10+).
Verified on Gradle 8.8, 8.10.2 and 9.0.0: shadow jar entries and
sizes identical to the 8.1.1 output, 103 unit tests pass.